### PR TITLE
(WIP) Add item and special field + delivery and outlaw item missions

### DIFF
--- a/Data/Item/index.idx
+++ b/Data/Item/index.idx
@@ -1,5 +1,5 @@
 ﻿{
-"Version": "0.7.1.0",
+"Version": "0.7.2.0",
 "Object": {
 "$type": "System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib],[RogueEssence.Data.EntrySummary, RogueEssence]], System.Private.CoreLib",
 "berry_aspear": {
@@ -2713,6 +2713,30 @@
 },
 "Released": true,
 "Comment": "Only works when another synergy scarf is worn by a nearby ally.\r\nBoosts all stats by 10%.\r\nActs as a pass scarf in a pinch.\r\n\r\n",
+"SortOrder": 0
+},
+"stolen_scarf": {
+"$type": "RogueEssence.Data.ItemEntrySummary, RogueEssence",
+"UsageType": 0,
+"States": [],
+"Name": {
+"DefaultText": "Stolen Scarf",
+"LocalTexts": {}
+},
+"Released": true,
+"Comment": "",
+"SortOrder": 0
+},
+"lost_scarf": {
+"$type": "RogueEssence.Data.ItemEntrySummary, RogueEssence",
+"UsageType": 0,
+"States": [],
+"Name": {
+"DefaultText": "Lost Scarf",
+"LocalTexts": {}
+},
+"Released": true,
+"Comment": "",
 "SortOrder": 0
 }
 }

--- a/Data/Item/lost_scarf.json
+++ b/Data/Item/lost_scarf.json
@@ -1,0 +1,193 @@
+﻿{
+"Version": "0.7.1.0",
+"Object": {
+"$type": "RogueEssence.Data.ItemData, RogueEssence",
+"Name": {
+"DefaultText": "Lost Scarf",
+"LocalTexts": {}
+},
+"Desc": {
+"DefaultText": "A lost scarf.",
+"LocalTexts": {}
+},
+"Released": true,
+"Comment": "",
+"Sprite": "Scarf_2_Orange",
+"Icon": -1,
+"SortCategory": 0,
+"Price": 0,
+"Rarity": 0,
+"MaxStack": 0,
+"CannotDrop": true,
+"BagEffect": false,
+"ItemStates": [],
+"UseAction": {
+"$type": "RogueEssence.Dungeon.AttackAction, RogueEssence",
+"HitTiles": false,
+"BurstTiles": 0,
+"Emitter": {
+"$type": "RogueEssence.Content.EmptyFiniteEmitter, RogueEssence",
+"LocHeight": 0
+},
+"WideAngle": 0,
+"CharAnimData": {
+"$type": "RogueEssence.Dungeon.CharAnimProcess, RogueEssence",
+"Process": 0,
+"AnimOverride": 0
+},
+"TargetAlignments": 0,
+"TileEmitter": {
+"$type": "RogueEssence.Content.EmptyFiniteEmitter, RogueEssence",
+"LocHeight": 0
+},
+"PreActions": [],
+"ActionFX": {
+"Delay": 0,
+"Sound": "",
+"Emitter": {
+"$type": "RogueEssence.Content.EmptyFiniteEmitter, RogueEssence",
+"LocHeight": 0
+},
+"ScreenMovement": {
+"MinShake": 0,
+"MaxShake": 0,
+"MaxShakeTime": 0
+}
+},
+"LagBehindTime": 0
+},
+"Explosion": {
+"TargetAlignments": 0,
+"HitTiles": false,
+"Range": 0,
+"Speed": 0,
+"TileEmitter": {
+"$type": "RogueEssence.Content.EmptyFiniteEmitter, RogueEssence",
+"LocHeight": 0
+},
+"Emitter": {
+"$type": "RogueEssence.Content.EmptyCircleSquareEmitter, RogueEssence",
+"LocHeight": 0
+},
+"IntroFX": [],
+"ExplodeFX": {
+"Delay": 0,
+"Sound": "",
+"Emitter": {
+"$type": "RogueEssence.Content.EmptyFiniteEmitter, RogueEssence",
+"LocHeight": 0
+},
+"ScreenMovement": {
+"MinShake": 0,
+"MaxShake": 0,
+"MaxShakeTime": 0
+}
+}
+},
+"UseEvent": {
+"Element": "",
+"Category": 0,
+"HitRate": -1,
+"SkillStates": [],
+"BeforeTryActions": [],
+"BeforeActions": [],
+"OnActions": [],
+"BeforeExplosions": [],
+"BeforeHits": [],
+"OnHits": [],
+"OnHitTiles": [],
+"AfterActions": [],
+"ElementEffects": [],
+"IntroFX": [],
+"HitFX": {
+"Delay": 0,
+"Sound": "",
+"Emitter": {
+"$type": "RogueEssence.Content.EmptyFiniteEmitter, RogueEssence",
+"LocHeight": 0
+},
+"ScreenMovement": {
+"MinShake": 0,
+"MaxShake": 0,
+"MaxShakeTime": 0
+}
+},
+"HitCharAction": {
+"$type": "RogueEssence.Dungeon.CharAnimProcess, RogueEssence",
+"Process": 0,
+"AnimOverride": 0
+}
+},
+"UsageType": 0,
+"ArcThrow": false,
+"BreakOnThrow": false,
+"ThrowAnim": {
+"AnimIndex": "",
+"FrameTime": 1,
+"StartFrame": -1,
+"EndFrame": -1,
+"AnimDir": -1,
+"Alpha": 255,
+"AnimFlip": 0
+},
+"ProximityEvent": {
+"Radius": -1,
+"TargetAlignments": 0,
+"BeforeExplosions": [],
+"OnEquips": [],
+"OnPickups": [],
+"BeforeStatusAdds": [],
+"OnStatusAdds": [],
+"OnStatusRemoves": [],
+"OnMapStatusAdds": [],
+"OnMapStatusRemoves": [],
+"OnMapStarts": [],
+"OnTurnStarts": [],
+"OnTurnEnds": [],
+"OnMapTurnEnds": [],
+"OnWalks": [],
+"OnDeaths": [],
+"OnRefresh": [],
+"BeforeTryActions": [],
+"BeforeActions": [],
+"OnActions": [],
+"BeforeHittings": [],
+"BeforeBeingHits": [],
+"AfterHittings": [],
+"AfterBeingHits": [],
+"OnHitTiles": [],
+"AfterActions": [],
+"UserElementEffects": [],
+"TargetElementEffects": [],
+"ModifyHPs": [],
+"RestoreHPs": []
+},
+"OnEquips": [],
+"OnPickups": [],
+"BeforeStatusAdds": [],
+"OnStatusAdds": [],
+"OnStatusRemoves": [],
+"OnMapStatusAdds": [],
+"OnMapStatusRemoves": [],
+"OnMapStarts": [],
+"OnTurnStarts": [],
+"OnTurnEnds": [],
+"OnMapTurnEnds": [],
+"OnWalks": [],
+"OnDeaths": [],
+"OnRefresh": [],
+"BeforeTryActions": [],
+"BeforeActions": [],
+"OnActions": [],
+"BeforeHittings": [],
+"BeforeBeingHits": [],
+"AfterHittings": [],
+"AfterBeingHits": [],
+"OnHitTiles": [],
+"AfterActions": [],
+"UserElementEffects": [],
+"TargetElementEffects": [],
+"ModifyHPs": [],
+"RestoreHPs": []
+}
+}

--- a/Data/Item/stolen_scarf.json
+++ b/Data/Item/stolen_scarf.json
@@ -1,0 +1,193 @@
+﻿{
+"Version": "0.7.2.0",
+"Object": {
+"$type": "RogueEssence.Data.ItemData, RogueEssence",
+"Name": {
+"DefaultText": "Stolen Scarf",
+"LocalTexts": {}
+},
+"Desc": {
+"DefaultText": "A stolen scarf.",
+"LocalTexts": {}
+},
+"Released": true,
+"Comment": "",
+"Sprite": "Scarf_Tan",
+"Icon": -1,
+"SortCategory": 0,
+"Price": 0,
+"Rarity": 0,
+"MaxStack": 0,
+"CannotDrop": false,
+"BagEffect": true,
+"ItemStates": [],
+"UseAction": {
+"$type": "RogueEssence.Dungeon.AttackAction, RogueEssence",
+"HitTiles": false,
+"BurstTiles": 0,
+"Emitter": {
+"$type": "RogueEssence.Content.EmptyFiniteEmitter, RogueEssence",
+"LocHeight": 0
+},
+"WideAngle": 0,
+"CharAnimData": {
+"$type": "RogueEssence.Dungeon.CharAnimProcess, RogueEssence",
+"Process": 0,
+"AnimOverride": 0
+},
+"TargetAlignments": 0,
+"TileEmitter": {
+"$type": "RogueEssence.Content.EmptyFiniteEmitter, RogueEssence",
+"LocHeight": 0
+},
+"PreActions": [],
+"ActionFX": {
+"Delay": 0,
+"Sound": "",
+"Emitter": {
+"$type": "RogueEssence.Content.EmptyFiniteEmitter, RogueEssence",
+"LocHeight": 0
+},
+"ScreenMovement": {
+"MinShake": 0,
+"MaxShake": 0,
+"MaxShakeTime": 0
+}
+},
+"LagBehindTime": 0
+},
+"Explosion": {
+"TargetAlignments": 0,
+"HitTiles": false,
+"Range": 0,
+"Speed": 0,
+"TileEmitter": {
+"$type": "RogueEssence.Content.EmptyFiniteEmitter, RogueEssence",
+"LocHeight": 0
+},
+"Emitter": {
+"$type": "RogueEssence.Content.EmptyCircleSquareEmitter, RogueEssence",
+"LocHeight": 0
+},
+"IntroFX": [],
+"ExplodeFX": {
+"Delay": 0,
+"Sound": "",
+"Emitter": {
+"$type": "RogueEssence.Content.EmptyFiniteEmitter, RogueEssence",
+"LocHeight": 0
+},
+"ScreenMovement": {
+"MinShake": 0,
+"MaxShake": 0,
+"MaxShakeTime": 0
+}
+}
+},
+"UseEvent": {
+"Element": "",
+"Category": 0,
+"HitRate": -1,
+"SkillStates": [],
+"BeforeTryActions": [],
+"BeforeActions": [],
+"OnActions": [],
+"BeforeExplosions": [],
+"BeforeHits": [],
+"OnHits": [],
+"OnHitTiles": [],
+"AfterActions": [],
+"ElementEffects": [],
+"IntroFX": [],
+"HitFX": {
+"Delay": 0,
+"Sound": "",
+"Emitter": {
+"$type": "RogueEssence.Content.EmptyFiniteEmitter, RogueEssence",
+"LocHeight": 0
+},
+"ScreenMovement": {
+"MinShake": 0,
+"MaxShake": 0,
+"MaxShakeTime": 0
+}
+},
+"HitCharAction": {
+"$type": "RogueEssence.Dungeon.CharAnimProcess, RogueEssence",
+"Process": 0,
+"AnimOverride": 0
+}
+},
+"UsageType": 0,
+"ArcThrow": false,
+"BreakOnThrow": false,
+"ThrowAnim": {
+"AnimIndex": "",
+"FrameTime": 1,
+"StartFrame": -1,
+"EndFrame": -1,
+"AnimDir": -1,
+"Alpha": 255,
+"AnimFlip": 0
+},
+"ProximityEvent": {
+"Radius": -1,
+"TargetAlignments": 0,
+"BeforeExplosions": [],
+"OnEquips": [],
+"OnPickups": [],
+"BeforeStatusAdds": [],
+"OnStatusAdds": [],
+"OnStatusRemoves": [],
+"OnMapStatusAdds": [],
+"OnMapStatusRemoves": [],
+"OnMapStarts": [],
+"OnTurnStarts": [],
+"OnTurnEnds": [],
+"OnMapTurnEnds": [],
+"OnWalks": [],
+"OnDeaths": [],
+"OnRefresh": [],
+"BeforeTryActions": [],
+"BeforeActions": [],
+"OnActions": [],
+"BeforeHittings": [],
+"BeforeBeingHits": [],
+"AfterHittings": [],
+"AfterBeingHits": [],
+"OnHitTiles": [],
+"AfterActions": [],
+"UserElementEffects": [],
+"TargetElementEffects": [],
+"ModifyHPs": [],
+"RestoreHPs": []
+},
+"OnEquips": [],
+"OnPickups": [],
+"BeforeStatusAdds": [],
+"OnStatusAdds": [],
+"OnStatusRemoves": [],
+"OnMapStatusAdds": [],
+"OnMapStatusRemoves": [],
+"OnMapStarts": [],
+"OnTurnStarts": [],
+"OnTurnEnds": [],
+"OnMapTurnEnds": [],
+"OnWalks": [],
+"OnDeaths": [],
+"OnRefresh": [],
+"BeforeTryActions": [],
+"BeforeActions": [],
+"OnActions": [],
+"BeforeHittings": [],
+"BeforeBeingHits": [],
+"AfterHittings": [],
+"AfterBeingHits": [],
+"OnHitTiles": [],
+"AfterActions": [],
+"UserElementEffects": [],
+"TargetElementEffects": [],
+"ModifyHPs": [],
+"RestoreHPs": []
+}
+}

--- a/Data/Misc/Rarity.json
+++ b/Data/Misc/Rarity.json
@@ -1,5 +1,5 @@
 ﻿{
-"Version": "0.7.1.0",
+"Version": "0.7.2.0",
 "Object": {
 "$type": "PMDC.Data.RarityData, PMDC",
 "RarityMap": {

--- a/Data/Script/GeneralFunctions.lua
+++ b/Data/Script/GeneralFunctions.lua
@@ -1381,3 +1381,36 @@ function GeneralFunctions.PrintPlotVariables()
 	print("BreloomGirafarigConvo = " .. tostring(SV.Chapter3.BreloomGirafarigConvo))
 
 end 
+
+function GeneralFunctions.TableContains(table, val)
+	for i=1,#table do
+		 if table[i] == val then 
+				return true
+		 end
+	end
+	return false
+end
+
+function GeneralFunctions.PrintMissionType(mission)
+	local val = mission.Type
+
+	if val == COMMON.MISSION_TYPE_RESCUE then
+		PrintInfo("=====RESCUE=====")
+  elseif val == COMMON.MISSION_TYPE_ESCORT then
+		PrintInfo("=====ESCORT=====")
+	elseif val == COMMON.MISSION_TYPE_EXPLORATION then
+		PrintInfo("=====EXPLORATION=====")
+  elseif val == COMMON.MISSION_TYPE_OUTLAW then 
+		PrintInfo("=====OUTLAW=====")
+	elseif val == COMMON.MISSION_TYPE_OUTLAW_FLEE then
+		PrintInfo("=====OUTLAW_FLEE=====")
+	elseif val == COMMON.MISSION_TYPE_OUTLAW_MONSTER_HOUSE then
+		PrintInfo("=====OUTLAW_MONSTER_HOUSE=====")
+	elseif val == COMMON.MISSION_TYPE_LOST_ITEM then 
+		PrintInfo("=====LOST_ITEM=====")
+	elseif val == COMMON.MISSION_TYPE_DELIVERY then 
+		PrintInfo("=====OUTLAW_MONSTER_HOUSE=====")
+  elseif val == COMMON.MISSION_TYPE_OUTLAW_ITEM then 
+		PrintInfo("=====OUTLAW_ITEM=====")
+  end
+end 

--- a/Data/Script/common.lua
+++ b/Data/Script/common.lua
@@ -1033,13 +1033,14 @@ function COMMON.EnterDungeonMissionCheck(zoneId, segmentID)
   for name, mission in pairs(SV.TakenBoard) do
     PrintInfo("Checking Mission: "..tostring(name))
     if mission.Taken and mission.Completion == COMMON.MISSION_INCOMPLETE and zoneId == mission.Zone and segmentID == mission.Segment and mission.Client ~= "" then
-      if mission.Type == COMMON.MISSION_TYPE_ESCORT then -- escort
+      if mission.Type == COMMON.MISSION_TYPE_ESCORT or mission.Type == COMMON.MISSION_TYPE_EXPLORATION then -- escort
         -- add escort to team
         local player_count = GAME:GetPlayerPartyCount()
         local guest_count = GAME:GetPlayerGuestCount()
         if player_count + guest_count >= 4 then
           local state = 0
           while state > -1 do
+            UI:ResetSpeaker()
             UI:WaitShowDialogue("Have one of your team members return to the guild to make room for your client, " .. _DATA:GetMonster(mission.Client):GetColoredName() .. ".")
             local MemberReturnMenu = CreateMemberReturnMenu()
             local menu = MemberReturnMenu:new()
@@ -1065,6 +1066,7 @@ function COMMON.EnterDungeonMissionCheck(zoneId, segmentID)
         local level = math.floor(MISSION_GEN.EXPECTED_LEVEL[mission.Zone] * 0.80)
         local new_mob = _DATA.Save.ActiveTeam:CreatePlayer(_DATA.Save.Rand, mon_id, level, "", -1)
         _DATA.Save.ActiveTeam.Guests:Add(new_mob)
+        
         -- place in a legal position on map
         local dest = _ZONE.CurrentMap:GetClosestTileForChar(new_mob, _DATA.Save.ActiveTeam.Leader.CharLoc)
         local endLoc = _DATA.Save.ActiveTeam.Leader.CharLoc
@@ -1093,7 +1095,7 @@ function COMMON.ExitDungeonMissionCheck(zoneId, segmentID)
   for name, mission in ipairs(SV.TakenBoard) do
     PrintInfo("Checking Mission: "..tostring(name))
     if mission.Taken and mission.Completion == COMMON.MISSION_INCOMPLETE and zoneId == mission.Zone and segmentID == mission.Segment then
-      if mission.Type == COMMON.MISSION_TYPE_ESCORT then -- escort
+      if mission.Type == COMMON.MISSION_TYPE_ESCORT or mission.Type == COMMON.MISSION_TYPE_EXPLORATION then -- escort
           -- remove the escort from the party
         local escort = COMMON.FindMissionEscort(name)
         if escort then

--- a/Data/Script/common.lua
+++ b/Data/Script/common.lua
@@ -91,6 +91,13 @@ end
 COMMON.MISSION_TYPE_RESCUE = 0
 COMMON.MISSION_TYPE_ESCORT = 1
 COMMON.MISSION_TYPE_OUTLAW = 2
+COMMON.MISSION_TYPE_EXPLORATION = 3
+COMMON.MISSION_TYPE_LOST_ITEM = 4
+COMMON.MISSION_TYPE_OUTLAW_ITEM = 5
+COMMON.MISSION_TYPE_OUTLAW_FLEE = 6
+COMMON.MISSION_TYPE_OUTLAW_MONSTER_HOUSE = 7
+COMMON.MISSION_TYPE_DELIVERY = 8
+
 
 COMMON.MISSION_INCOMPLETE = 0
 COMMON.MISSION_COMPLETE = 1
@@ -1025,8 +1032,8 @@ function COMMON.EnterDungeonMissionCheck(zoneId, segmentID)
   SOUND:StopBGM()
   for name, mission in pairs(SV.TakenBoard) do
     PrintInfo("Checking Mission: "..tostring(name))
-    if mission.Taken and mission.Completion == 0 and zoneId == mission.Zone and segmentID == mission.Segment and mission.Client ~= "" then
-      if mission.Type == 1 then -- escort
+    if mission.Taken and mission.Completion == COMMON.MISSION_INCOMPLETE and zoneId == mission.Zone and segmentID == mission.Segment and mission.Client ~= "" then
+      if mission.Type == COMMON.MISSION_TYPE_ESCORT then -- escort
         -- add escort to team
         local player_count = GAME:GetPlayerPartyCount()
         local guest_count = GAME:GetPlayerGuestCount()
@@ -1085,8 +1092,8 @@ end
 function COMMON.ExitDungeonMissionCheck(zoneId, segmentID)
   for name, mission in ipairs(SV.TakenBoard) do
     PrintInfo("Checking Mission: "..tostring(name))
-    if mission.Taken and mission.Completion == 0 and zoneId == mission.Zone and segmentID == mission.Segment then
-      if mission.Type == 1 then -- escort
+    if mission.Taken and mission.Completion == COMMON.MISSION_INCOMPLETE and zoneId == mission.Zone and segmentID == mission.Segment then
+      if mission.Type == COMMON.MISSION_TYPE_ESCORT then -- escort
           -- remove the escort from the party
         local escort = COMMON.FindMissionEscort(name)
         if escort then

--- a/Data/Script/event_mapgen.lua
+++ b/Data/Script/event_mapgen.lua
@@ -27,10 +27,10 @@ function ZONE_GEN_SCRIPT.SpawnMissionNpcFromSV(zoneContext, context, queue, seed
 	  and zoneContext.CurrentSegment == mission.Segment and zoneContext.CurrentID + 1 == mission.Floor then
       PrintInfo("Spawning Mission Goal")
       local outlaw_arr = { 
-        COMMON.MISSION_TYPE_OUTLAW, 
-        COMMON.MISSION_TYPE_OUTLAW_ITEM, 
-        COMMON.MISSION_TYPE_OUTLAW_FLEE, 
-        COMMON.MISSION_TYPE_OUTLAW_MONSTER_HOUSE 
+        COMMON.MISSION_TYPE_OUTLAW,
+        COMMON.MISSION_TYPE_OUTLAW_ITEM,
+        COMMON.MISSION_TYPE_OUTLAW_FLEE,
+        COMMON.MISSION_TYPE_OUTLAW_MONSTER_HOUSE
       }
 
       if GeneralFunctions.TableContains(outlaw_arr, mission.Type) then -- outlaw
@@ -77,15 +77,14 @@ function ZONE_GEN_SCRIPT.SpawnMissionNpcFromSV(zoneContext, context, queue, seed
         post_mob.BaseForm = RogueEssence.Dungeon.MonsterID(mission.Target, 0, "normal", Gender.Unknown)
         post_mob.Tactic = "slow_wander"
         post_mob.Level = RogueElements.RandRange(50)
-        GeneralFunctions.PrintMissionType(mission)
         if mission.Type == COMMON.MISSION_TYPE_RESCUE or mission.Type == COMMON.MISSION_TYPE_DELIVERY then -- rescue
           local dialogue = RogueEssence.Dungeon.BattleScriptEvent("RescueReached")
-            post_mob.SpawnFeatures:Add(PMDC.LevelGen.MobSpawnInteractable(dialogue))
-            post_mob.SpawnFeatures:Add(PMDC.LevelGen.MobSpawnLuaTable('{ Mission = "'..name..'" }'))
-          elseif mission.Type == COMMON.MISSION_TYPE_ESCORT then -- escort
+          post_mob.SpawnFeatures:Add(PMDC.LevelGen.MobSpawnInteractable(dialogue))
+          post_mob.SpawnFeatures:Add(PMDC.LevelGen.MobSpawnLuaTable('{ Mission = "'..name..'" }'))
+        elseif mission.Type == COMMON.MISSION_TYPE_ESCORT then -- escort
           local dialogue = RogueEssence.Dungeon.BattleScriptEvent("EscortRescueReached")
-            post_mob.SpawnFeatures:Add(PMDC.LevelGen.MobSpawnInteractable(dialogue))
-            post_mob.SpawnFeatures:Add(PMDC.LevelGen.MobSpawnLuaTable('{ Mission = "'..name..'" }'))
+          post_mob.SpawnFeatures:Add(PMDC.LevelGen.MobSpawnInteractable(dialogue))
+          post_mob.SpawnFeatures:Add(PMDC.LevelGen.MobSpawnLuaTable('{ Mission = "'..name..'" }'))
         end
         specificTeam.Spawns:Add(post_mob)
           PrintInfo("Creating Spawn")
@@ -106,22 +105,21 @@ function ZONE_GEN_SCRIPT.SpawnMissionNpcFromSV(zoneContext, context, queue, seed
       end
     end
   end
-  
   if destinationFloor then
     -- add destination floor notification
     local activeEffect = RogueEssence.Data.ActiveEffect()
     activeEffect.OnMapStarts:Add(-6, RogueEssence.Dungeon.SingleCharScriptEvent("DestinationFloor"))
-	local destNote = LUA_ENGINE:MakeGenericType( MapEffectStepType, { MapGenContextType }, { activeEffect })
-	local priority = RogueElements.Priority(-6)
-	queue:Enqueue(priority, destNote)
+	  local destNote = LUA_ENGINE:MakeGenericType( MapEffectStepType, { MapGenContextType }, { activeEffect })
+	  local priority = RogueElements.Priority(-6)
+	  queue:Enqueue(priority, destNote)
   end
   if outlawFloor then
     -- add destination floor notification
     local activeEffect = RogueEssence.Data.ActiveEffect()
     activeEffect.OnMapStarts:Add(-6, RogueEssence.Dungeon.SingleCharScriptEvent("OutlawFloor"))
-	local destNote = LUA_ENGINE:MakeGenericType( MapEffectStepType, { MapGenContextType }, { activeEffect })
-	local priority = RogueElements.Priority(-6)
-	queue:Enqueue(priority, destNote)
+	  local destNote = LUA_ENGINE:MakeGenericType( MapEffectStepType, { MapGenContextType }, { activeEffect })
+	  local priority = RogueElements.Priority(-6)
+	  queue:Enqueue(priority, destNote)
   end
 end
 

--- a/Data/Script/event_mapgen.lua
+++ b/Data/Script/event_mapgen.lua
@@ -10,29 +10,50 @@ end
 PresetMultiTeamSpawnerType = luanet.import_type('RogueEssence.LevelGen.PresetMultiTeamSpawner`1')
 PlaceRandomMobsStepType = luanet.import_type('RogueEssence.LevelGen.PlaceRandomMobsStep`1')
 PlaceEntranceMobsStepType = luanet.import_type('RogueEssence.LevelGen.PlaceEntranceMobsStep`2')
+MonsterHouseStepType = luanet.import_type('RogueEssence.LevelGen.MonsterHouseStep`1')
+
 MapEffectStepType = luanet.import_type('RogueEssence.LevelGen.MapEffectStep`1')
 MapGenContextType = luanet.import_type('RogueEssence.LevelGen.ListMapGenContext')
 EntranceType = luanet.import_type('RogueEssence.LevelGen.MapGenEntrance')
 
+
 function ZONE_GEN_SCRIPT.SpawnMissionNpcFromSV(zoneContext, context, queue, seed, args)
-  -- choose a the floor to spawn it on
+  -- TODO try to add monster house gen step first
+ 
   local destinationFloor = false
   local outlawFloor = false
   for name, mission in pairs(SV.TakenBoard) do
     if mission.Taken and mission.Completion == COMMON.MISSION_INCOMPLETE and zoneContext.CurrentZone == mission.Zone
 	  and zoneContext.CurrentSegment == mission.Segment and zoneContext.CurrentID + 1 == mission.Floor then
       PrintInfo("Spawning Mission Goal")
-      if mission.Type == COMMON.MISSION_TYPE_OUTLAW then -- outlaw
+      local outlaw_arr = { 
+        COMMON.MISSION_TYPE_OUTLAW, 
+        COMMON.MISSION_TYPE_OUTLAW_ITEM, 
+        COMMON.MISSION_TYPE_OUTLAW_FLEE, 
+        COMMON.MISSION_TYPE_OUTLAW_MONSTER_HOUSE 
+      }
+
+      if GeneralFunctions.TableContains(outlaw_arr, mission.Type) then -- outlaw
         local specificTeam = RogueEssence.LevelGen.SpecificTeamSpawner()
         local post_mob = RogueEssence.LevelGen.MobSpawn()
         post_mob.BaseForm = RogueEssence.Dungeon.MonsterID(mission.Target, 0, "normal", Gender.Unknown)
-        post_mob.Tactic = "boss"
+
+        if mission.Type == COMMON.MISSION_TYPE_OUTLAW_FLEE then
+          --TODO: Change to get tact
+          post_mob.Tactic = "get_away"
+        else
+          post_mob.Tactic = "boss"
+        end
         -- Grab the outlaw level
         post_mob.Level = RogueElements.RandRange(
           math.floor(MISSION_GEN.EXPECTED_LEVEL[mission.Zone] * 1.15)
         )
         
         post_mob.SpawnFeatures:Add(PMDC.LevelGen.MobSpawnLuaTable('{ Mission = "'..name..'" }'))
+        if mission.Type == COMMON.MISSION_TYPE_OUTLAW_ITEM then
+          local item_feature = PMDC.LevelGen.MobSpawnItem(true, mission.Item)
+          post_mob.SpawnFeatures:Add(item_feature)
+        end
 
         local boost_feature = PMDC.LevelGen.MobSpawnBoost()
         boost_feature.MaxHPBonus = MISSION_GEN.EXPECTED_LEVEL[mission.Zone] * 2;
@@ -51,12 +72,13 @@ function ZONE_GEN_SCRIPT.SpawnMissionNpcFromSV(zoneContext, context, queue, seed
         PrintInfo("Done")
         outlawFloor = true
       else
-          local specificTeam = RogueEssence.LevelGen.SpecificTeamSpawner()
-          local post_mob = RogueEssence.LevelGen.MobSpawn()
-          post_mob.BaseForm = RogueEssence.Dungeon.MonsterID(mission.Target, 0, "normal", Gender.Unknown)
-          post_mob.Tactic = "slow_wander"
-          post_mob.Level = RogueElements.RandRange(50)
-        if mission.Type == COMMON.MISSION_TYPE_RESCUE then -- rescue
+        local specificTeam = RogueEssence.LevelGen.SpecificTeamSpawner()
+        local post_mob = RogueEssence.LevelGen.MobSpawn()
+        post_mob.BaseForm = RogueEssence.Dungeon.MonsterID(mission.Target, 0, "normal", Gender.Unknown)
+        post_mob.Tactic = "slow_wander"
+        post_mob.Level = RogueElements.RandRange(50)
+        GeneralFunctions.PrintMissionType(mission)
+        if mission.Type == COMMON.MISSION_TYPE_RESCUE or mission.Type == COMMON.MISSION_TYPE_DELIVERY then -- rescue
           local dialogue = RogueEssence.Dungeon.BattleScriptEvent("RescueReached")
             post_mob.SpawnFeatures:Add(PMDC.LevelGen.MobSpawnInteractable(dialogue))
             post_mob.SpawnFeatures:Add(PMDC.LevelGen.MobSpawnLuaTable('{ Mission = "'..name..'" }'))
@@ -317,6 +339,3 @@ function FLOOR_GEN_SCRIPT.CreateRiver(map, args)
 	
 	
 end
- 
-
-

--- a/Data/Script/event_single.lua
+++ b/Data/Script/event_single.lua
@@ -163,7 +163,6 @@ function SINGLE_CHAR_SCRIPT.DestinationFloor(owner, ownerChar, context, args)
 	end
 end
 
-
 function SINGLE_CHAR_SCRIPT.OutlawFloor(owner, ownerChar, context, args)
   local tbl = LTBL(context.User)
 	if tbl ~= nil and tbl.Mission then

--- a/Data/Script/ground/guild_second_floor/init.lua
+++ b/Data/Script/ground/guild_second_floor/init.lua
@@ -248,10 +248,11 @@ function guild_second_floor.Hand_In_Missions()
 									Segment = -1,
 									Floor = -1,
 									Reward = "",
-									Type = "",
+									Type = -1,
 									Completion = -1,
 									Taken = false,
-									Difficulty = ""
+									Difficulty = "",
+									Item = "",
 								}
 		end
 	end 

--- a/Data/Script/ground/testmap/init.lua
+++ b/Data/Script/ground/testmap/init.lua
@@ -76,7 +76,7 @@ function testmap.See_Taken_Action(chara, activator)
 	for i = 1, 8, 1 do
 		UI:WaitShowDialogue("Job " .. tostring(i) .. ": Client: " .. SV.TakenBoard[i].Client .. " Target: " .. SV.TakenBoard[i].Target ..
 			" Zone: " .. SV.TakenBoard[i].Zone .. " Reward: " .. SV.TakenBoard[i].Reward .. " Floor: " .. SV.TakenBoard[i].Floor .. " Type: "
-			.. SV.TakenBoard[i].Type .. " Completion: " .. SV.TakenBoard[i].Completion .. " Taken: " .. tostring(SV.TakenBoard[i].Taken) .. " Difficulty: " .. SV.TakenBoard[i].Difficulty)			
+			.. SV.TakenBoard[i].Type .. " Completion: " .. SV.TakenBoard[i].Completion .. " Taken: " .. tostring(SV.TakenBoard[i].Taken) .. " Difficulty: " .. SV.TakenBoard[i].Difficulty .. " Item: " .. SV.TakenBoard[i].Item)			
 	end
 	UI:SetAutoFinish(false)
 end
@@ -88,7 +88,7 @@ function testmap.See_Mission_Action(chara, activator)
 	for i = 1, 8, 1 do
 		UI:WaitShowDialogue("Job " .. tostring(i) .. ": Client: " .. SV.MissionBoard[i].Client .. " Target: " .. SV.MissionBoard[i].Target ..
 			" Zone: " .. SV.MissionBoard[i].Zone .. " Reward: " .. SV.MissionBoard[i].Reward .. " Floor: " .. SV.MissionBoard[i].Floor .. " Type: "
-			.. SV.MissionBoard[i].Type .. " Completion: " .. SV.MissionBoard[i].Completion .. " Taken: " .. tostring(SV.MissionBoard[i].Taken) .. " Difficulty: " .. SV.MissionBoard[i].Difficulty)			
+			.. SV.MissionBoard[i].Type .. " Completion: " .. SV.MissionBoard[i].Completion .. " Taken: " .. tostring(SV.MissionBoard[i].Taken) .. " Difficulty: " .. SV.MissionBoard[i].Difficulty .. " Item: " .. SV.MissionBoard[i].Item)			
 	end
 	UI:SetAutoFinish(false)
 end
@@ -99,7 +99,7 @@ function testmap.See_Outlaw_Action(chara, activator)
 	for i = 1, 8, 1 do
 		UI:WaitShowDialogue("Job " .. tostring(i) .. ": Client: " .. SV.OutlawBoard[i].Client .. " Target: " .. SV.OutlawBoard[i].Target ..
 			" Zone: " .. SV.OutlawBoard[i].Zone .. " Reward: " .. SV.OutlawBoard[i].Reward .. " Floor: " .. SV.OutlawBoard[i].Floor .. " Type: "
-			.. SV.OutlawBoard[i].Type .. " Completion: " .. SV.OutlawBoard[i].Completion .. " Taken: " .. tostring(SV.OutlawBoard[i].Taken) .. " Difficulty: " .. SV.OutlawBoard[i].Difficulty)			
+			.. SV.OutlawBoard[i].Type .. " Completion: " .. SV.OutlawBoard[i].Completion .. " Taken: " .. tostring(SV.OutlawBoard[i].Taken) .. " Difficulty: " .. SV.OutlawBoard[i].Difficulty ..  " Item: " .. SV.OutlawBoard[i].Item)			
 	end
 	UI:SetAutoFinish(false)
 end

--- a/Data/Script/mission_gen.lua
+++ b/Data/Script/mission_gen.lua
@@ -475,9 +475,20 @@ MISSION_GEN.REWARDS = {
 		{'tm_drain_punch', 5}},
 	--additional, special, unique rewards. todo
 	SPECIAL = {}
-	
 }
 
+MISSION_GEN.LOST_ITEMS = {
+	"lost_scarf"
+}
+
+MISSION_GEN.STOLEN_ITEMS = {
+	"stolen_scarf"
+}
+
+MISSION_GEN.DELIVERABLE_ITEMS = {
+	"berry_oran",
+	"berry_leppa",
+}
 
 --"order" of dungeons
 MISSION_GEN.DUNGEON_ORDER = {}
@@ -532,7 +543,7 @@ function MISSION_GEN.ResetBoards()
 --jobs on the mission board.
 SV.MissionBoard =
 {
-		{
+	{
 		Client = "",
 		Target = "",
 		Flavor = "",
@@ -541,10 +552,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},
 	{
 		Client = "",
@@ -555,10 +567,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -569,10 +582,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -583,10 +597,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -597,10 +612,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -611,10 +627,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},
 	{
 		Client = "",
@@ -625,10 +642,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -639,10 +657,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	}
 
 }
@@ -659,10 +678,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},
 	{
 		Client = "",
@@ -673,10 +693,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -687,10 +708,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -701,10 +723,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -715,10 +738,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -729,10 +753,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},
 	{
 		Client = "",
@@ -743,10 +768,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -757,10 +783,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	}
 }
 
@@ -795,17 +822,22 @@ function MISSION_GEN.GenerateBoard(board_type)
 	
 	--generate jobs
 	for i = 1, jobs_to_make, 1 do 
-		--choose a dungeon, client, target, etc
+		--choose a dungeon, client, target, item, etc
 		local dungeon = dungeon_list[math.random(1, #dungeon_list)]
 		local client = MISSION_GEN.POKEMON[math.random(1, #MISSION_GEN.POKEMON)]
-
+		local item = ""
 		
 		--generate the objective. 10% chance of escort vs rescue.
 		local objective 
 		if mission_type == "Outlaw" then 
-			objective = COMMON.MISSION_TYPE_OUTLAW
+			if math.random(1, 2) == 1 then
+				objective = COMMON.MISSION_TYPE_OUTLAW
+			else
+				objective = COMMON.MISSION_TYPE_OUTLAW_ITEM
+			end
 		else
-			if math.random(1, 10) == 1 then 
+			local roll = math.random(1, 10)
+			if roll <= 1 then 
 				--if there's already an escort mission generated for this dungeon, don't gen another one and just make it a rescue.
 				objective = COMMON.MISSION_TYPE_ESCORT 
 				--only check from 1 to i-1 to save time.
@@ -822,9 +854,24 @@ function MISSION_GEN.GenerateBoard(board_type)
 						break
 					end
 				end
-			else 
+			elseif roll <= 2 then
+				-- TODO - Apply the same logic to escort missions
+				objective = COMMON.MISSION_TYPE_EXPLORATION
+			elseif roll <= 4 then
+				objective = COMMON.MISSION_TYPE_DELIVERY
+			elseif roll <= 6 then
+				objective = COMMON.MISSION_TYPE_LOST_ITEM
+			else
 				objective = COMMON.MISSION_TYPE_RESCUE
 			end
+		end
+
+		if objective == COMMON.MISSION_TYPE_DELIVERY then
+			item = MISSION_GEN.DELIVERABLE_ITEMS[math.random(1, #MISSION_GEN.DELIVERABLE_ITEMS)]
+		elseif objective == COMMON.MISSION_TYPE_OUTLAW_ITEM then
+			item = MISSION_GEN.STOLEN_ITEMS[math.random(1, #MISSION_GEN.STOLEN_ITEMS)]
+		elseif objective == COMMON.MISSION_TYPE_LOST_ITEM then
+			item = MISSION_GEN.LOST_ITEMS[math.random(1, #MISSION_GEN.LOST_ITEMS)]
 		end
 		
 		
@@ -846,12 +893,18 @@ function MISSION_GEN.GenerateBoard(board_type)
 			end
 		end
 		
-		--up the difficulty by 1 if its an outlaw or escort mission.
+
 		local difficulty = MISSION_GEN.DUNGEON_DIFFICULTY[dungeon]
-		if objective == COMMON.MISSION_TYPE_ESCORT or objective == COMMON.MISSION_TYPE_OUTLAW then
-				difficulty = MISSION_GEN.ORDER_TO_DIFF[MISSION_GEN.DIFF_TO_ORDER[difficulty]+1]
+		local offset = 0
+		--up the difficulty by 1 if its an outlaw or escort mission.
+		local difficult_objectives = { COMMON.MISSION_TYPE_ESCORT, COMMON.MISSION_TYPE_OUTLAW, COMMON.MISSION_TYPE_OUTLAW_FLEE, COMMON.MISSION_TYPE_OUTLAW_ITEM }
+		if GeneralFunctions.TableContains(difficult_objectives, objective) then
+			offset = 1
+		--up the difficulty by 2 if its an outlaw monster house
+		elseif objective == COMMON.MISSION_TYPE_OUTLAW_MONSTER_HOUSE then
+			offset = 2
 		end
-		
+		difficulty = MISSION_GEN.ORDER_TO_DIFF[MISSION_GEN.DIFF_TO_ORDER[difficulty]+offset]
 		--should pretty much always be in segment 0 for missions
 		local segment = 0
 		print(MISSION_GEN.DIFF_REWARDS[difficulty])
@@ -897,7 +950,7 @@ function MISSION_GEN.GenerateBoard(board_type)
 		local mission_floor = math.random(math.floor(zone.CountedFloors * .55), zone.CountedFloors)
 		
 		--don't generate this particular job slot if this floor's already been taken.
-		--a bit of a lazy approach, perphaps upgrade in future?
+		--a bit of a lazy approach, perhaps upgrade in future?
 		if not MISSION_GEN.has_value(used_floors, mission_floor) then 
 			if mission_type == "Outlaw" then
 				SV.OutlawBoard[i].Client = client
@@ -912,6 +965,7 @@ function MISSION_GEN.GenerateBoard(board_type)
 				SV.OutlawBoard[i].Completion = MISSION_GEN.INCOMPLETE
 				SV.OutlawBoard[i].Taken = false
 				SV.OutlawBoard[i].Difficulty = difficulty
+				SV.OutlawBoard[i].Item = item
 			else 
 				SV.MissionBoard[i].Client = client
 				SV.MissionBoard[i].Target = target
@@ -925,6 +979,7 @@ function MISSION_GEN.GenerateBoard(board_type)
 				SV.MissionBoard[i].Completion = MISSION_GEN.INCOMPLETE
 				SV.MissionBoard[i].Taken = false
 				SV.MissionBoard[i].Difficulty = difficulty
+				SV.MissionBoard[i].Item = item
 			end
 		end
 			
@@ -977,7 +1032,7 @@ function JobMenu:initialize(job_type, job_number, parent_board_menu)
   --get relevant board
   local job
   if job_type == 'taken' then
-	job = SV.TakenBoard[job_number]
+		job = SV.TakenBoard[job_number]
   elseif job_type == 'outlaw' then
   	job = SV.OutlawBoard[job_number]
   else --default to mission board
@@ -1000,15 +1055,26 @@ function JobMenu:initialize(job_type, job_number, parent_board_menu)
   self.target = ""
   if job.Target ~= '' then self.target = _DATA:GetMonster(job.Target):GetColoredName() end
   
+	self.item = ""
+	if job.Item ~= '' then self.item = _DATA:GetItem(job.Item):GetColoredName() end
+  
   self.objective = ""
   self.type = job.Type
   
   if self.type == COMMON.MISSION_TYPE_RESCUE then
-	self.objective = "Rescue " .. self.client .. "."
+		self.objective = "Rescue " .. self.client .. "."
   elseif self.type == COMMON.MISSION_TYPE_ESCORT then
     self.objective = "Escort " .. self.client .. " to " .. self.target .. "."
-  elseif self.type == COMMON.MISSION_TYPE_OUTLAW then 
-	self.objective = "Arrest " .. self.target .. "."
+	elseif self.type == COMMON.MISSION_TYPE_EXPLORATION then
+		self.objective = "Explore with " .. self.client .. "."
+  elseif self.type == COMMON.MISSION_TYPE_OUTLAW or self.type == COMMON.MISSION_TYPE_OUTLAW_FLEE or self.type == COMMON.MISSION_TYPE_OUTLAW_MONSTER_HOUSE then 
+		self.objective = "Arrest " .. self.target .. "."
+	elseif self.type == COMMON.MISSION_TYPE_LOST_ITEM then 
+		self.objective = "Find " .. self.item .. " for " .. self.client .. "."
+	elseif self.type == COMMON.MISSION_TYPE_DELIVERY then 
+		self.objective = "Deliver " .. self.item .. " to " .. self.client .. "."
+  elseif self.type == COMMON.MISSION_TYPE_OUTLAW_ITEM then 
+		self.objective = "Retrieve " .. self.item .. " from " .. self.target .. "."
   end
   
   
@@ -1076,10 +1142,11 @@ function JobMenu:DeleteJob()
 										Segment = -1,
 										Floor = -1,
 										Reward = "",
-										Type = "",
+										Type = -1,
 										Completion = -1,
 										Taken = false,
-										Difficulty = ""
+										Difficulty = "",
+										Item = ""
 									}
 	
 	MISSION_GEN.SortTaken()

--- a/Data/Script/mission_gen.lua
+++ b/Data/Script/mission_gen.lua
@@ -1,5 +1,5 @@
 require 'common'
-
+require 'GeneralFunctions'
 
 --Halcyon Custom work:
 --Code in this folder is used to generate, display, and handle randomized missions
@@ -477,6 +477,42 @@ MISSION_GEN.REWARDS = {
 	SPECIAL = {}
 }
 
+MISSION_GEN.SPECIAL_RESCUE_RIVAL = "RIVAL"
+MISSION_GEN.SPECIAL_RESCUE_CHILD = "CHILD"
+MISSION_GEN.SPECIAL_RESCUE_LOVER = "LOVER"
+MISSION_GEN.SPECIAL_RESCUE_FRIEND = "FRIEND"
+
+
+MISSION_GEN.SPECIAL_RESCUE_OPTIONS = {
+	MISSION_GEN.SPECIAL_RESCUE_RIVAL,
+	MISSION_GEN.SPECIAL_RESCUE_CHILD,
+	MISSION_GEN.SPECIAL_RESCUE_LOVER,
+	MISSION_GEN.SPECIAL_RESCUE_FRIEND
+}
+
+MISSION_GEN.SPECIAL_LOVER_PAIRS = {
+
+}
+
+MISSION_GEN.SPECIAL_CHILD_PAIRS = {
+
+}
+
+MISSION_GEN.SPECIAL_FRIENDS_PAIRS = {
+
+}
+
+MISSION_GEN.SPECIAL_RIVAL_PAIRS = {
+
+}
+
+
+
+MISSION_GEN.SPECIAL_OUTLAW = {
+
+}
+
+
 MISSION_GEN.LOST_ITEMS = {
 	"lost_scarf"
 }
@@ -556,7 +592,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},
 	{
 		Client = "",
@@ -571,7 +608,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -586,7 +624,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -601,7 +640,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -616,7 +656,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -631,7 +672,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},
 	{
 		Client = "",
@@ -646,7 +688,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -661,7 +704,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	}
 
 }
@@ -682,7 +726,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},
 	{
 		Client = "",
@@ -697,7 +742,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -712,7 +758,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -727,7 +774,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -742,7 +790,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -757,7 +806,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},
 	{
 		Client = "",
@@ -772,7 +822,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -787,7 +838,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	}
 }
 
@@ -826,7 +878,8 @@ function MISSION_GEN.GenerateBoard(board_type)
 		local dungeon = dungeon_list[math.random(1, #dungeon_list)]
 		local client = MISSION_GEN.POKEMON[math.random(1, #MISSION_GEN.POKEMON)]
 		local item = ""
-		
+		local special = ""
+
 		--generate the objective. 10% chance of escort vs rescue.
 		local objective 
 		if mission_type == "Outlaw" then 
@@ -855,14 +908,17 @@ function MISSION_GEN.GenerateBoard(board_type)
 					end
 				end
 			elseif roll <= 2 then
-				-- TODO - Apply the same logic to escort missions
+				-- TODO - Apply the same logic from escort missions to exploration
 				objective = COMMON.MISSION_TYPE_EXPLORATION
 			elseif roll <= 4 then
 				objective = COMMON.MISSION_TYPE_DELIVERY
+--				objective = COMMON.MISSION_TYPE_EXPLORATION
 			elseif roll <= 6 then
 				objective = COMMON.MISSION_TYPE_LOST_ITEM
+--				objective = COMMON.MISSION_TYPE_EXPLORATION
 			else
 				objective = COMMON.MISSION_TYPE_RESCUE
+--				objective = COMMON.MISSION_TYPE_EXPLORATION
 			end
 		end
 
@@ -873,7 +929,19 @@ function MISSION_GEN.GenerateBoard(board_type)
 		elseif objective == COMMON.MISSION_TYPE_LOST_ITEM then
 			item = MISSION_GEN.LOST_ITEMS[math.random(1, #MISSION_GEN.LOST_ITEMS)]
 		end
-		
+
+		-- TODO handle special cases 
+		if objective == COMMON.MISSION_TYPE_RESCUE and math.random(1, 10) == 1 then
+			special = MISSION_GEN.SPECIAL_RESCUE_OPTIONS[math.random(1, #MISSION_GEN.SPECIAL_RESCUE_OPTIONS)]
+			if special == MISSION_GEN.SPECIAL_RESCUE_LOVER then
+
+			elseif special == MISSION_GEN.SPECIAL_RESCUE_CHILD then
+
+			elseif special == MISSION_GEN.SPECIAL_RESCUE_RIVAL then
+
+			elseif special == MISSION_GEN.SPECIAL_RESCUE_FRIEND then
+			end
+		end
 		
 		--50% chance that the client and target are the same. Target is the escort if its an escort mission.
 		--It is possible for this to roll the same target as the client again, which is fine.
@@ -966,6 +1034,7 @@ function MISSION_GEN.GenerateBoard(board_type)
 				SV.OutlawBoard[i].Taken = false
 				SV.OutlawBoard[i].Difficulty = difficulty
 				SV.OutlawBoard[i].Item = item
+				SV.OutlawBoard[i].Special = special
 			else 
 				SV.MissionBoard[i].Client = client
 				SV.MissionBoard[i].Target = target
@@ -980,6 +1049,7 @@ function MISSION_GEN.GenerateBoard(board_type)
 				SV.MissionBoard[i].Taken = false
 				SV.MissionBoard[i].Difficulty = difficulty
 				SV.MissionBoard[i].Item = item
+				SV.MissionBoard[i].Special = special
 			end
 		end
 			
@@ -1146,7 +1216,8 @@ function JobMenu:DeleteJob()
 										Completion = -1,
 										Taken = false,
 										Difficulty = "",
-										Item = ""
+										Item = "",
+										Special = ""
 									}
 	
 	MISSION_GEN.SortTaken()

--- a/Data/Script/scriptvars.lua
+++ b/Data/Script/scriptvars.lua
@@ -65,7 +65,8 @@ SV.TakenBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},
 	{
 		Client = "",
@@ -80,7 +81,8 @@ SV.TakenBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -95,7 +97,8 @@ SV.TakenBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -110,7 +113,8 @@ SV.TakenBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -125,7 +129,8 @@ SV.TakenBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -140,7 +145,8 @@ SV.TakenBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},
 	{
 		Client = "",
@@ -155,7 +161,8 @@ SV.TakenBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -170,7 +177,8 @@ SV.TakenBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	}
 
 }
@@ -191,7 +199,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},
 	{
 		Client = "",
@@ -206,7 +215,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -221,7 +231,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -236,7 +247,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -251,7 +263,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -266,7 +279,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},
 	{
 		Client = "",
@@ -281,7 +295,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -296,7 +311,8 @@ SV.MissionBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	}
 
 }
@@ -317,7 +333,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},
 	{
 		Client = "",
@@ -332,7 +349,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -347,7 +365,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -362,7 +381,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -377,7 +397,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -392,7 +413,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},
 	{
 		Client = "",
@@ -407,7 +429,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	},	
 	{
 		Client = "",
@@ -422,7 +445,8 @@ SV.OutlawBoard =
 		Completion = -1,
 		Taken = false,
 		Difficulty = "",
-		Item = ""
+		Item = "",
+		Special = ""
 	}
 }
 		

--- a/Data/Script/scriptvars.lua
+++ b/Data/Script/scriptvars.lua
@@ -61,10 +61,11 @@ SV.TakenBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},
 	{
 		Client = "",
@@ -75,10 +76,11 @@ SV.TakenBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -89,10 +91,11 @@ SV.TakenBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -103,10 +106,11 @@ SV.TakenBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -117,10 +121,11 @@ SV.TakenBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -131,10 +136,11 @@ SV.TakenBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},
 	{
 		Client = "",
@@ -145,10 +151,11 @@ SV.TakenBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -159,10 +166,11 @@ SV.TakenBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	}
 
 }
@@ -179,10 +187,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},
 	{
 		Client = "",
@@ -193,10 +202,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -207,10 +217,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -221,10 +232,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -235,10 +247,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -249,10 +262,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},
 	{
 		Client = "",
@@ -263,10 +277,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -277,10 +292,11 @@ SV.MissionBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	}
 
 }
@@ -297,10 +313,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},
 	{
 		Client = "",
@@ -311,10 +328,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = 1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -325,10 +343,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -339,10 +358,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -353,10 +373,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -367,10 +388,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},
 	{
 		Client = "",
@@ -381,10 +403,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	},	
 	{
 		Client = "",
@@ -395,10 +418,11 @@ SV.OutlawBoard =
 		Segment = -1,
 		Floor = -1,
 		Reward = "",
-		Type = "",
+		Type = -1,
 		Completion = -1,
 		Taken = false,
-		Difficulty = ""
+		Difficulty = "",
+		Item = ""
 	}
 }
 		

--- a/Data/Script/services/debug_tools/init.lua
+++ b/Data/Script/services/debug_tools/init.lua
@@ -96,23 +96,23 @@ function DebugTools:OnNewGame()
 	  talk_evt = RogueEssence.Dungeon.BattleScriptEvent("PartnerInteract")
 	  _DATA.Save.ActiveTeam.Players[1].ActionEvents:Add(talk_evt)
 	  
-	  --mon_id = RogueEssence.Dungeon.MonsterID("tropius", 0, "normal", Gender.Male)
-	  --_DATA.Save.ActiveTeam.Players:Add(_DATA.Save.ActiveTeam:CreatePlayer(_DATA.Save.Rand, mon_id, 50, "", 0))
+	  mon_id = RogueEssence.Dungeon.MonsterID("tropius", 0, "normal", Gender.Male)
+	  _DATA.Save.ActiveTeam.Players:Add(_DATA.Save.ActiveTeam:CreatePlayer(_DATA.Save.Rand, mon_id, 50, "", 0))
 	  
 	  
-		--_DATA.Save.ActiveTeam.Players[0].MaxHPBonus = 3
-		--_DATA.Save.ActiveTeam.Players[0].AtkBonus = 1
-		--_DATA.Save.ActiveTeam.Players[0].DefBonus = 1
-		--_DATA.Save.ActiveTeam.Players[0].MAtkBonus = 1
-		--_DATA.Save.ActiveTeam.Players[0].MDefBonus = 1
-	--	_DATA.Save.ActiveTeam.Players[0].SpeedBonus = 1
+		_DATA.Save.ActiveTeam.Players[0].MaxHPBonus = 3
+		_DATA.Save.ActiveTeam.Players[0].AtkBonus = 1
+		_DATA.Save.ActiveTeam.Players[0].DefBonus = 1
+		_DATA.Save.ActiveTeam.Players[0].MAtkBonus = 1
+		_DATA.Save.ActiveTeam.Players[0].MDefBonus = 1
+		_DATA.Save.ActiveTeam.Players[0].SpeedBonus = 1
 
-		--_DATA.Save.ActiveTeam.Players[1].MaxHPBonus = 3
-		--_DATA.Save.ActiveTeam.Players[1].AtkBonus = 1
-		--_DATA.Save.ActiveTeam.Players[1].DefBonus = 1
-		--_DATA.Save.ActiveTeam.Players[1].MAtkBonus = 1
-		--_DATA.Save.ActiveTeam.Players[1].MDefBonus = 1
-		--_DATA.Save.ActiveTeam.Players[1].SpeedBonus = 1
+		_DATA.Save.ActiveTeam.Players[1].MaxHPBonus = 3
+		_DATA.Save.ActiveTeam.Players[1].AtkBonus = 1
+		_DATA.Save.ActiveTeam.Players[1].DefBonus = 1
+		_DATA.Save.ActiveTeam.Players[1].MAtkBonus = 1
+		_DATA.Save.ActiveTeam.Players[1].MDefBonus = 1
+		_DATA.Save.ActiveTeam.Players[1].SpeedBonus = 1
 		
 	  --audino 
 	   -- mon_id = RogueEssence.Dungeon.MonsterID("audino", 0, "normal", Gender.Female)
@@ -242,10 +242,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},
 		{
 			Client = "",
@@ -256,10 +257,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},	
 		{
 			Client = "",
@@ -270,10 +272,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},	
 		{
 			Client = "",
@@ -284,10 +287,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},	
 		{
 			Client = "",
@@ -298,10 +302,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},	
 		{
 			Client = "",
@@ -312,10 +317,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},
 		{
 			Client = "",
@@ -326,10 +332,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},	
 		{
 			Client = "",
@@ -340,10 +347,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		}
 
 	}
@@ -361,10 +369,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},
 		{
 			Client = "",
@@ -375,10 +384,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},	
 		{
 			Client = "",
@@ -389,10 +399,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},	
 		{
 			Client = "",
@@ -403,10 +414,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},	
 		{
 			Client = "",
@@ -417,10 +429,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},	
 		{
 			Client = "",
@@ -431,10 +444,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},
 		{
 			Client = "",
@@ -445,10 +459,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},	
 		{
 			Client = "",
@@ -459,10 +474,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		}
 
 	}
@@ -480,10 +496,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},
 		{
 			Client = "",
@@ -494,10 +511,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},	
 		{
 			Client = "",
@@ -508,10 +526,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},	
 		{
 			Client = "",
@@ -522,10 +541,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},	
 		{
 			Client = "",
@@ -536,10 +556,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},	
 		{
 			Client = "",
@@ -550,10 +571,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},
 		{
 			Client = "",
@@ -564,10 +586,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		},	
 		{
 			Client = "",
@@ -578,10 +601,11 @@ end
 			Segment = -1,
 			Floor = -1,
 			Reward = "",
-			Type = "",
+			Type = -1,
 			Completion = -1,
 			Taken = false,
-			Difficulty = ""
+			Difficulty = "",
+			Item = ""
 		}
 	}
 	end

--- a/Data/Script/services/debug_tools/init.lua
+++ b/Data/Script/services/debug_tools/init.lua
@@ -246,7 +246,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},
 		{
 			Client = "",
@@ -261,7 +262,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},	
 		{
 			Client = "",
@@ -276,7 +278,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},	
 		{
 			Client = "",
@@ -291,7 +294,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},	
 		{
 			Client = "",
@@ -306,7 +310,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},	
 		{
 			Client = "",
@@ -321,7 +326,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},
 		{
 			Client = "",
@@ -336,7 +342,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},	
 		{
 			Client = "",
@@ -351,7 +358,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		}
 
 	}
@@ -373,7 +381,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},
 		{
 			Client = "",
@@ -388,7 +397,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},	
 		{
 			Client = "",
@@ -403,7 +413,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},	
 		{
 			Client = "",
@@ -418,7 +429,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},	
 		{
 			Client = "",
@@ -433,7 +445,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},	
 		{
 			Client = "",
@@ -448,7 +461,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},
 		{
 			Client = "",
@@ -463,7 +477,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},	
 		{
 			Client = "",
@@ -478,7 +493,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		}
 
 	}
@@ -500,7 +516,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},
 		{
 			Client = "",
@@ -515,7 +532,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},	
 		{
 			Client = "",
@@ -530,7 +548,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},	
 		{
 			Client = "",
@@ -545,7 +564,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},	
 		{
 			Client = "",
@@ -560,7 +580,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},	
 		{
 			Client = "",
@@ -575,7 +596,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},
 		{
 			Client = "",
@@ -590,7 +612,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		},	
 		{
 			Client = "",
@@ -605,7 +628,8 @@ end
 			Completion = -1,
 			Taken = false,
 			Difficulty = "",
-			Item = ""
+			Item = "",
+			Special = ""
 		}
 	}
 	end


### PR DESCRIPTION
TODO:
- Fix seen Pokemon
- Cutscenes for the new missions
- Modify exploration mission gen to not collide with anything
- Add more "Lost", "Stolen", "Deliverable" items to the lua table
- Complete mission functionality for OUTLAW_MONSTER_HOUSE, OUTLAW_FLEE, EXPLORATION, LOST_ITEM
- Create flavor text for additional mission types
- Generate special clients and targets for RESCUE missions (which can be changed to include other missions)