### PR TITLE
consistent color names for missions

### DIFF
--- a/Data/Script/GeneralFunctions.lua
+++ b/Data/Script/GeneralFunctions.lua
@@ -1456,6 +1456,14 @@ function GeneralFunctions.RemoveAllItems()
   end
 end
 
+function GeneralFunctions.RemoveAllGuests()
+	local guest_count = GAME:GetPlayerGuestCount()
+	for i = 0, guest_count - 1, 1 do --beam everyone else out
+		PrintInfo("REMOVING GUESTS")
+		GAME:RemovePlayerGuest(0)
+	end
+end
+
 function GeneralFunctions.PrintMissionType(mission)
 	local val = mission.Type
 

--- a/Data/Script/event_battle.lua
+++ b/Data/Script/event_battle.lua
@@ -93,8 +93,8 @@ function BATTLE_SCRIPT.EscortInteract(owner, ownerChar, context, args)
   local job = SV.TakenBoard[mission_slot]
   
   if job.Type == COMMON.MISSION_TYPE_EXPLORATION then
-	local floor = MISSION_GEN.STAIR_TYPE[job.Zone] .. '[color=#00FFFF]' .. tostring(job.Floor) .. '[color]' .. "F"
-	UI:WaitShowDialogue("Please, take me to " .. floor .. "!")
+		local floor = MISSION_GEN.STAIR_TYPE[job.Zone] .. '[color=#00FFFF]' .. tostring(job.Floor) .. '[color]' .. "F"
+		UI:WaitShowDialogue("Please, take me to " .. floor .. "!")
   elseif job.Type == COMMON.MISSION_TYPE_ESCORT then
     if job.Special == MISSION_GEN.SPECIAL_CLIENT_LOVER then
 	  UI:WaitShowDialogue("Please, bring me to my love! I'm counting on you!")
@@ -107,7 +107,9 @@ end
 
 function BATTLE_SCRIPT.RescueReached(owner, ownerChar, context, args)
 	context.CancelState.Cancel = true
-	local targetName = context.Target:GetDisplayName(true);
+
+	local targetName = _DATA:GetMonster(context.Target.BaseForm.Species):GetColoredName()
+
   local oldDir = context.Target.CharDir
 
 	local tbl = LTBL(context.Target)

--- a/Data/Script/event_single.lua
+++ b/Data/Script/event_single.lua
@@ -213,16 +213,11 @@ function SINGLE_CHAR_SCRIPT.OnOutlawDeath(owner, ownerChar, context, args)
 	if mission_num ~= nil then
 		local curr_mission = SV.TakenBoard[mission_num]
 		local outlaw_name = _DATA:GetMonster(curr_mission.Target):GetColoredName()
-		PrintInfo(tostring(curr_mission.Completion))
 		SOUND:PlayBGM(_ZONE.CurrentMap.Music, true)
 		SV.TemporaryFlags.MissionCompleted = true
 		curr_mission.Completion = 1
-		-- if no outlaws are found in the map, return music to normal and remove this status from the map
-		SOUND:PlayBGM(_ZONE.CurrentMap.Music, true)
 		GAME:WaitFrames(50)
 		UI:ResetSpeaker()
-		-- if no outlaws of the mission list, mark quest as complete
-		--Mark mission completion flags
 		UI:WaitShowDialogue("Yes!\nKnocked out outlaw " .. outlaw_name .. "!")
 		--Clear but remember minimap state
 		SV.TemporaryFlags.PriorMapSetting = _DUNGEON.ShowMap
@@ -240,8 +235,6 @@ function SINGLE_CHAR_SCRIPT.OutlawItemCheck(owner, ownerChar, context, args)
 		local found_outlaw = COMMON.FindNpcWithTable(true, "Mission", mission_num)
 		if found_outlaw then
 			remaining_outlaw = true
-		else
-			outlaw_name = _DATA:GetMonster(curr_mission.Target):GetColoredName()
 		end
 
 		if not remaining_outlaw then
@@ -275,8 +268,9 @@ end
 function SINGLE_CHAR_SCRIPT.MissionGuestCheck(owner, ownerChar, context, args)
 	local tbl = LTBL(context.User)
 	if tbl ~= nil and tbl.Escort ~= nil then
+		local targetName = _DATA:GetMonster(context.User.BaseForm.Species):GetColoredName()
 		UI:ResetSpeaker()
-		UI:WaitShowDialogue("Oh no! " ..  context.User:GetDisplayName(true) .. " fainted!")
+		UI:WaitShowDialogue("Oh no! " ..  targetName .. " fainted!")
 		GAME:WaitFrames(40)
 		GeneralFunctions.WarpOut()
 		GAME:WaitFrames(80)

--- a/Data/Universal.json
+++ b/Data/Universal.json
@@ -1,5 +1,5 @@
 ﻿{
-"Version": "0.7.7.1",
+"Version": "0.7.10.0",
 "Object": {
 "$type": "RogueEssence.Data.ActiveEffect, RogueEssence",
 "UniversalStates": [
@@ -684,18 +684,6 @@
 "Value": {
 "$type": "PMDC.Dungeon.ImpostorReviveEvent, PMDC",
 "AbilityID": "imposter"
-}
-},
-{
-"Key": {
-"str": [
-9
-]
-},
-"Value": {
-"$type": "RogueEssence.Dungeon.SingleCharScriptEvent, RogueEssence",
-"Script": "MissionGuestCheck",
-"ArgTable": "{}"
 }
 },
 {


### PR DESCRIPTION
This PR does three things:

- Add the consistent green names for rescuees and escorts
- Moves the MissionGuestCheck OnDeath event to the zone gen script rather than having as a "Universal" script
- Cleans up a little bit of code