### PR TITLE
move outlaw spawn out of global event

### DIFF
--- a/Data/Script/event_mapgen.lua
+++ b/Data/Script/event_mapgen.lua
@@ -186,6 +186,7 @@ function ZONE_GEN_SCRIPT.GenerateMissionFromSV(zoneContext, context, queue, seed
       activeEffect.OnTurnEnds:Add(-6, RogueEssence.Dungeon.SingleCharScriptEvent("OnMonsterHouseOutlawCheck", '{ Mission = '..missionNum..' }'))
     end
 
+    activeEffect.OnMapStarts:Add(-11, RogueEssence.Dungeon.SingleCharScriptEvent("SpawnOutlaw", '{ Mission = '..missionNum..' }'))
     activeEffect.OnMapStarts:Add(-6, RogueEssence.Dungeon.SingleCharScriptEvent("OutlawFloor", '{ Mission = '..missionNum..' }'))
     tbl.MissionType = COMMON.MISSION_BOARD_OUTLAW
   end

--- a/Data/Script/event_single.lua
+++ b/Data/Script/event_single.lua
@@ -452,6 +452,18 @@ function SINGLE_CHAR_SCRIPT.OnMonsterHouseOutlawCheck(owner, ownerChar, context,
 	end
 end
 
+function SINGLE_CHAR_SCRIPT.SpawnOutlaw(owner, ownerChar, context, args) 
+	if context.User == GAME:GetPlayerPartyMember(0) then
+		local mission_num = args.Mission
+		local curr_mission = SV.TakenBoard[mission_num]
+		if curr_mission.Completion == COMMON.MISSION_INCOMPLETE then
+			local origin = _DATA.Save.ActiveTeam.Leader.CharLoc
+			local radius = 2
+			SpawnOutlaw(origin, radius, mission_num)
+		end
+	end
+end
+
 function SINGLE_CHAR_SCRIPT.OutlawCheck(owner, ownerChar, context, args)
 	local mission_num = args.Mission
 	local curr_mission = SV.TakenBoard[mission_num]

--- a/Data/Script/services/debug_tools/init.lua
+++ b/Data/Script/services/debug_tools/init.lua
@@ -841,18 +841,18 @@ function DebugTools:OnLossPenalty(save)
   --end
 end
 
-function DebugTools:OnDungeonMapInit(mapname, mapobj)
-	if GAME:GetPlayerPartyCount() > 1 and GeneralFunctions.TableContains(MISSION_GEN.DUNGEON_LIST, _ZONE.CurrentZoneID) then
-		local partner = GAME:GetPlayerPartyMember(1)
-		local tbl = LTBL(partner)
-		if tbl.MissionType == COMMON.MISSION_BOARD_OUTLAW then
-			local origin = _DATA.Save.ActiveTeam.Leader.CharLoc
-			local radius = 2
-			local mission_num = tbl.MissionNumber
-			SpawnOutlaw(origin, radius, mission_num)
-		end
-	end
-end
+-- function DebugTools:OnDungeonMapInit(mapname, mapobj)
+-- 	if GAME:GetPlayerPartyCount() > 1 and GeneralFunctions.TableContains(MISSION_GEN.DUNGEON_LIST, _ZONE.CurrentZoneID) then
+-- 		local partner = GAME:GetPlayerPartyMember(1)
+-- 		local tbl = LTBL(partner)
+-- 		if tbl.MissionType == COMMON.MISSION_BOARD_OUTLAW then
+-- 			local origin = _DATA.Save.ActiveTeam.Leader.CharLoc
+-- 			local radius = 2
+-- 			local mission_num = tbl.MissionNumber
+-- 			SpawnOutlaw(origin, radius, mission_num)
+-- 		end
+-- 	end
+-- end
 
 ---Summary
 -- Subscribe to all channels this service wants callbacks from
@@ -863,7 +863,7 @@ function DebugTools:Subscribe(med)
   med:Subscribe("DebugTools", EngineServiceEvents.NewGame,        function() self.OnNewGame(self) end )
   med:Subscribe("DebugTools", EngineServiceEvents.UpgradeSave,        function() self.OnUpgrade(self) end )
   med:Subscribe("DebugTools", EngineServiceEvents.LossPenalty,        function(_, args) self.OnLossPenalty(self, args[0]) end )
-	med:Subscribe("DebugTools", EngineServiceEvents.DungeonMapInit,        function(_, args) self.OnDungeonMapInit(self, args[0], args[1]) end )
+	-- med:Subscribe("DebugTools", EngineServiceEvents.DungeonMapInit,        function(_, args) self.OnDungeonMapInit(self, args[0], args[1]) end )
   --  med:Subscribe("DebugTools", EngineServiceEvents.GraphicsUnload,      function() self.OnGraphicsUnload(self) end )
   --  med:Subscribe("DebugTools", EngineServiceEvents.Restart,             function() self.OnRestart(self) end )
 end


### PR DESCRIPTION
Currently, the `OnDungeonMapInit` function gets called for every floor for every dungeon when checking for when to spawn outlaws. This PR improves this by moving the spawn outlaw to the `GenerateMissionFromSV` zone step. And it turns out, the outlaw is able to spawn before the fade-in since the fade-in has a priority of -10, while the SpawnOutlaw has a priority of -11. Before, I had a priority of -6, which caused the outlaw to spawn after the fade. 

